### PR TITLE
Use a fork of slack-irc

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:wily
+FROM ubuntu:xenial
 
 ENV DEBIAN_FRONTEND noninteractive
 
@@ -6,17 +6,20 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get dist-upgrade -y
 
 # Install requirements
-RUN apt-get install -y curl supervisor
+RUN apt-get install -y curl supervisor git make gcc g++ apt-utils libicu-dev
 
 # Install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_5.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
 RUN apt-get install --fix-missing -y nodejs
 
 # Get slack-irc
-RUN npm install -g slack-irc
+RUN git clone https://github.com/markus456/slack-irc.git && \
+    cd slack-irc && \
+    npm install && \
+    npm run build
 
 # Add configurations
-ADD config.json slack-irc/config.json
+ADD config.json /slack-irc/config.json
 
 # Add supervisor configs
 ADD supervisord.conf supervisord.conf

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -4,7 +4,7 @@ nodaemon=false
 [program:slack-irc]
 priority=30
 directory=/slack-irc
-command=slack-irc --config /slack-irc/config.json
+command=/slack-irc/dist/index.js --config /slack-irc/config.json
 user=root
 autostart=true
 autorestart=true


### PR DESCRIPTION
Use the markus456 fork of the slack-irc repo to allow relaying of bot
messages to IRC.

Upgraded Ubuntu to Xenial and Node.js to version 6.